### PR TITLE
Add option to hide connection failure messages.

### DIFF
--- a/gmailnotifier@denisigo/applet.js
+++ b/gmailnotifier@denisigo/applet.js
@@ -58,19 +58,21 @@ MyApplet.prototype = {
   },
   
   onGfError: function(a_code,a_params) {
-    switch (a_code){
-      case 'authFailed':
-        this.showNotify("GmailNotifier",_("Gmail authentication failed!"));
+    if(Settings.showerrors=='yes'){
+      switch (a_code){
+        case 'authFailed':
+          this.showNotify("GmailNotifier",_("Gmail authentication failed!"));
         this.set_applet_tooltip(_("Gmail authentication failed!"));
-      break;
-      case 'feedReadFailed':
-        this.showNotify("GmailNotifier",_("Gmail feed reading failed!"));
-        this.set_applet_tooltip(_("Gmail feed reading failed!"));
-      break;
-      case 'feedParseFailed':
-        this.showNotify("GmailNotifier",_("Gmail feed parsing failed!"));
-        this.set_applet_tooltip(_("Gmail feed parsing failed!"));
-      break;
+        break;
+        case 'feedReadFailed':
+          this.showNotify("GmailNotifier",_("Gmail feed reading failed!"));
+          this.set_applet_tooltip(_("Gmail feed reading failed!"));
+        break;
+        case 'feedParseFailed':
+          this.showNotify("GmailNotifier",_("Gmail feed parsing failed!"));
+          this.set_applet_tooltip(_("Gmail feed parsing failed!"));
+        break;
+      }
     }
   },
   

--- a/gmailnotifier@denisigo/settings.js
+++ b/gmailnotifier@denisigo/settings.js
@@ -18,3 +18,5 @@ password[0]='';
 // Mailbox checking timeout, seconds
 var checktimeout=60;
 
+var showerrors='yes';
+


### PR DESCRIPTION
When using a computer that isn't always connected to the internet, it gets annoying seeing the failure notifications coming up every few seconds. So I've added an option to disable the failure notifications, however they are on by default.
